### PR TITLE
Minor fix to Controlled Vocabulary

### DIFF
--- a/pyavm/cv.py
+++ b/pyavm/cv.py
@@ -82,8 +82,10 @@ METADATA_VERSION_CHOICES = [
 
 STRETCH_FUNCTION_CHOICES = [
     'Linear',
+    'Linear(x)',
     'Log',
     'Log(x)',
+    'Arcsinh',
     'Arcsinh(x)',
     'X^(1/2)'
 ]


### PR DESCRIPTION
At least, I think it's a fix.  I couldn't read the AVM from this Chandra image:
http://chandra.harvard.edu/photo/2009/gcenter/

so I added `Log(x)` to the `STRETCH_FUNCTION_CHOICES`. 
