### PR TITLE
Sometimes content is a List of None?

### DIFF
--- a/pyavm/datatypes.py
+++ b/pyavm/datatypes.py
@@ -79,7 +79,7 @@ class AVMString(AVMData):
             value = value[0]
         if isinstance(value, basestring):
             return value
-        elif not value:
+        elif value is None:
             return None
         else:
             raise TypeError("{0:s} is not a string or unicode".format(self.tag))
@@ -330,7 +330,7 @@ class AVMUnorderedList(AVMData):
             raise TypeError("Data needs to be a Python List.")
 
         # Check if all are None
-        if all([not v for v in values]):
+        if all([v is None for v in values]):
             return None
 
         # Check length


### PR DESCRIPTION
Test file is 'http://www.usm.uni-muenchen.de/people/preibisch/laboca-opt1000.jpg'

```
A = pyavm.AVM.from_image('laboca-opt1000.jpg')
Traceback (most recent call last):
  File "<ipython-input-150-8839f3a5b7fd>", line 1, in <module>
    A = pyavm.AVM.from_image('laboca-opt1000.jpg')
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/pyavm/avm.py", line 382, in from_image
    return cls.from_xml(xml)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/pyavm/avm.py", line 414, in from_xml
    content = avm_class.check_data(content)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/pyavm/datatypes.py", line 83, in check_data
    raise TypeError("{0:s} is not a string or unicode".format(self.tag))
TypeError: Spectral.Notes is not a string or unicode

> /Users/adam/virtual-python/lib/python2.7/site-packages/pyavm/datatypes.py(83)check_data()
     82         else:
---> 83             raise TypeError("{0:s} is not a string or unicode".format(self.tag))
     84

ipdb>
```

It seems that `value` is `None`, but it misses the `if not value` check because `content`, passed in to `check_data`, was `[None]` instead of just `None`
