### PR TITLE
Allow ``xmp_packet_index`` to be passed to ``from_image`` to select XMP packet to use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
 
 install:
    - export PYTHONIOENCODING=UTF8 # just in case
+   - pip install pip --upgrade
    - pip install pytest pillow numpy astropy
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ language: python
 sudo: false
 
 python:
-    - 2.6
     - 2.7
-    - 3.2
-    - 3.3
     - 3.5
     - 3.6
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ install:
    - pip install pytest pillow numpy astropy
 
 script:
-   - py.test pyavm
+   - py.test pyavm -p no:warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,18 @@
 language: python
 
+sudo: false
+
 python:
     - 2.6
     - 2.7
     - 3.2
     - 3.3
-
-before_install:
-   # We do this to make sure we get the dependencies so pip works below
-   - sudo apt-get update -qq
+    - 3.5
+    - 3.6
 
 install:
    - export PYTHONIOENCODING=UTF8 # just in case
-   - pip install pytest -q --use-mirrors
-   - pip install pillow -q --use-mirrors
-   - pip install numpy -q --use-mirrors
-   - pip install astropy -q --use-mirrors
+   - pip install pytest pillow numpy astropy
 
 script:
    - py.test pyavm

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ PyAVM is a module to represent, read, and write metadata following the
 Requirements
 ------------
 
-PyAVM supports Python 2.6, 2.7, 3.1, 3.2, and 3.3. No other dependencies are
+PyAVM supports Python 2.7 and 3.5+. No other dependencies are
 needed simply to read and embed AVM meta-data.
 
 However, the following optional dependencies are needed for more advanced

--- a/pyavm/avm.py
+++ b/pyavm/avm.py
@@ -364,13 +364,22 @@ class AVM(AVMContainer):
             return object.__getattr__(self, attribute)
 
     @classmethod
-    def from_image(cls, filename):
+    def from_image(cls, filename, xmp_packet_index=0):
         """
         Instantiate an AVM object from an existing image.
+
+        Parameters
+        ----------
+        filename : str
+            The filename of the image to read the AVM meta-data from
+        xmp_packet_index : int, optional
+            In cases where multiple XMP packets are present in the file, this
+            can be used to indicate which one to use. If not specified, this
+            defaults to the first XMP packet found.
         """
 
         # Get XMP data from file
-        xmp = extract_xmp(filename)
+        xmp = extract_xmp(filename, xmp_packet_index=xmp_packet_index)
 
         # Extract XML
         start = xmp.index("<?xpacket begin=")

--- a/pyavm/extract.py
+++ b/pyavm/extract.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division
 
+import re
 import struct
 import warnings
 
@@ -7,35 +8,43 @@ from .jpeg import is_jpeg, JPEGFile, JPEGSegment
 from .png import is_png, PNGFile, PNGChunk
 from .exceptions import NoXMPPacketFound
 
-def extract_xmp(image):
+def extract_xmp(image, xmp_packet_index=0):
 
     if is_jpeg(image):
 
         # Read in input file
         jpeg_file = JPEGFile.read(image)
 
+        xmp_segments = []
+
         # Loop through segments and search for XMP packet
         for segment in jpeg_file.segments:
             if segment.type == 'APP1':
                 if segment.bytes[4:32] == b'http://ns.adobe.com/xap/1.0/':
-                    return segment.bytes[32:]
+                    xmp_segments.append(segment.bytes[32:])
 
-        # No XMP data was found
-        raise NoXMPPacketFound("No XMP packet present in file")
+        if len(xmp_segments) > 0:
+            return xmp_segments[xmp_packet_index]
+        else:  # No XMP data was found
+            raise NoXMPPacketFound("No XMP packet present in file")
 
     elif is_png(image):
 
         # Read in input file
         png_file = PNGFile.read(image)
 
+        xmp_chunks = []
+
         # Loop through chunks and search for XMP packet
         for chunk in png_file.chunks:
             if chunk.type == 'iTXt':
                 if chunk.data.startswith(b'XML:com.adobe.xmp'):
-                    return chunk.data[22:]
+                    xmp_chunks.append(chunk.data[22:])
 
-        # No XMP data was found
-        raise NoXMPPacketFound("No XMP packet present in file")
+        if len(xmp_chunks) > 0:
+            return xmp_chunks[xmp_packet_index]
+        else:  # No XMP data was found
+            raise NoXMPPacketFound("No XMP packet present in file")
 
     else:
 
@@ -44,10 +53,12 @@ def extract_xmp(image):
         with open(image, 'rb') as fileobj:
             contents = fileobj.read()
 
-        try:
-            start = contents.index(b"<?xpacket begin=")
-            end = contents.index(b"</x:xmpmeta>") + 12
-        except ValueError:
+        start_positions = [m.start() for m in re.finditer(b"<?xpacket begin=", contents)]
+
+        if len(start_positions) > 0:
+            start = start_positions[xmp_packet_index] - 2
+            end = contents.index(b"</x:xmpmeta>", start) + 12
+        else:
             raise NoXMPPacketFound("No XMP packet present in file")
 
         return contents[start:end]

--- a/pyavm/extract.py
+++ b/pyavm/extract.py
@@ -32,6 +32,10 @@ def extract_xmp(image, xmp_packet_index=None):
                                   "xmp_packet_index was not specified, assuming "
                                   "xmp_packet_index=0")
                 xmp_packet_index = 0
+            elif xmp_packet_index >= len(xmp_segments):
+                raise IndexError("xmp_packet was set to {0} but only {1} "
+                                 "packets are present".format(xmp_packet_index,
+                                                              len(xmp_segments)))
             return xmp_segments[xmp_packet_index]
         else:  # No XMP data was found
             raise NoXMPPacketFound("No XMP packet present in file")
@@ -56,6 +60,10 @@ def extract_xmp(image, xmp_packet_index=None):
                                   "xmp_packet_index was not specified, assuming "
                                   "xmp_packet_index=0")
                 xmp_packet_index = 0
+            elif xmp_packet_index >= len(xmp_chunks):
+                raise IndexError("xmp_packet was set to {0} but only {1} "
+                                 "packets are present".format(xmp_packet_index,
+                                                              len(xmp_chunks)))
             return xmp_chunks[xmp_packet_index]
         else:  # No XMP data was found
             raise NoXMPPacketFound("No XMP packet present in file")
@@ -77,6 +85,10 @@ def extract_xmp(image, xmp_packet_index=None):
                                   "xmp_packet_index was not specified, assuming "
                                   "xmp_packet_index=0")
                 xmp_packet_index = 0
+            elif xmp_packet_index >= len(start_positions):
+                raise IndexError("xmp_packet was set to {0} but only {1} "
+                                 "packets are present".format(xmp_packet_index,
+                                                              len(start_positions)))
             start = start_positions[xmp_packet_index] - 2
             end = contents.index(b"</x:xmpmeta>", start) + 12
         else:

--- a/pyavm/extract.py
+++ b/pyavm/extract.py
@@ -1,14 +1,16 @@
 from __future__ import print_function, division
 
 import re
-import struct
 import warnings
 
-from .jpeg import is_jpeg, JPEGFile, JPEGSegment
-from .png import is_png, PNGFile, PNGChunk
+from .jpeg import is_jpeg, JPEGFile
+from .png import is_png, PNGFile
 from .exceptions import NoXMPPacketFound
 
-def extract_xmp(image, xmp_packet_index=0):
+__all__ = ['extract_xmp']
+
+
+def extract_xmp(image, xmp_packet_index=None):
 
     if is_jpeg(image):
 
@@ -24,6 +26,12 @@ def extract_xmp(image, xmp_packet_index=0):
                     xmp_segments.append(segment.bytes[32:])
 
         if len(xmp_segments) > 0:
+            if xmp_packet_index is None:
+                if len(xmp_segments) > 1:
+                    warnings.warn("Multiple XMP packets are present but "
+                                  "xmp_packet_index was not specified, assuming "
+                                  "xmp_packet_index=0")
+                xmp_packet_index = 0
             return xmp_segments[xmp_packet_index]
         else:  # No XMP data was found
             raise NoXMPPacketFound("No XMP packet present in file")
@@ -42,13 +50,20 @@ def extract_xmp(image, xmp_packet_index=0):
                     xmp_chunks.append(chunk.data[22:])
 
         if len(xmp_chunks) > 0:
+            if xmp_packet_index is None:
+                if len(xmp_chunks) > 1:
+                    warnings.warn("Multiple XMP packets are present but "
+                                  "xmp_packet_index was not specified, assuming "
+                                  "xmp_packet_index=0")
+                xmp_packet_index = 0
             return xmp_chunks[xmp_packet_index]
         else:  # No XMP data was found
             raise NoXMPPacketFound("No XMP packet present in file")
 
     else:
 
-        warnings.warn("Only PNG and JPEG files can be properly parsed - scanning file contents for XMP packet")
+        warnings.warn("Only PNG and JPEG files can be properly parsed "
+                      "- scanning file contents for XMP packet")
 
         with open(image, 'rb') as fileobj:
             contents = fileobj.read()
@@ -56,6 +71,12 @@ def extract_xmp(image, xmp_packet_index=0):
         start_positions = [m.start() for m in re.finditer(b"<?xpacket begin=", contents)]
 
         if len(start_positions) > 0:
+            if xmp_packet_index is None:
+                if len(start_positions) > 1:
+                    warnings.warn("Multiple XMP packets are present but "
+                                  "xmp_packet_index was not specified, assuming "
+                                  "xmp_packet_index=0")
+                xmp_packet_index = 0
             start = start_positions[xmp_packet_index] - 2
             end = contents.index(b"</x:xmpmeta>", start) + 12
         else:

--- a/pyavm/tests/test_main.py
+++ b/pyavm/tests/test_main.py
@@ -46,14 +46,13 @@ def test_to_wcs(filename):
 @pytest.mark.parametrize('filename', XML_FILES_WCS)
 def test_to_wcs_target_image(filename, tmpdir):
     from PIL import Image
-    image = Image.fromstring(data=b"1111", size=(2,2), mode="L")
+    image = Image.frombytes(data=b"1111", size=(2, 2), mode="L")
     image_file = tmpdir.join('test.png').strpath
     image.save(image_file)
     image.close()
     a = AVM.from_xml_file(filename)
     a.Spatial.ReferenceDimension = (30, 30)
     a.to_wcs(target_image=image_file)
-
 
 
 @pytest.mark.parametrize('filename', NO_WCS)


### PR DESCRIPTION
To-do:
- [x] emit warning if no value is passed and multiple XMP packets are present.
- [x] give nice error if index is too large
