### PR TITLE
python3: xml writing seems to require Bytes, not String

### DIFF
--- a/pyavm/avm.py
+++ b/pyavm/avm.py
@@ -27,10 +27,7 @@ except:
     basestring = unicode = str
 
 import warnings
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import BytesIO as StringIO
+from astropy.extern.six import BytesIO
 import xml.etree.ElementTree as et
 
 from .specs import SPECS, REVERSE_SPECS
@@ -397,7 +394,7 @@ class AVM(AVMContainer):
         self = cls()
 
         # Parse XML
-        tree = et.parse(StringIO(xml))
+        tree = et.parse(BytesIO(xml))
         root = tree.getroot()
         avm_content = parse_avm_content(root)
 
@@ -452,7 +449,7 @@ class AVM(AVMContainer):
 
         if use_full_header and self.Spatial.FITSheader is not None:
             print("Using full FITS header from Spatial.FITSheader")
-            header = fits.Header(txtfile=StringIO(self.Spatial.FITSheader))
+            header = fits.Header(txtfile=BytesIO(self.Spatial.FITSheader))
             return WCS(header)
 
         # Initializing WCS object
@@ -697,8 +694,8 @@ class AVM(AVMContainer):
         # Create XML Tree
         tree = et.ElementTree(root)
 
-        # Need to create a StringIO object to write to
-        s = StringIO()
+        # Need to create a BytesIO object to write to
+        s = BytesIO()
         tree.write(s, encoding='utf-8')
 
         # Rewind and read the contents

--- a/pyavm/avm.py
+++ b/pyavm/avm.py
@@ -370,9 +370,9 @@ class AVM(AVMContainer):
         xmp = extract_xmp(filename)
 
         # Extract XML
-        start = xmp.index("<?xpacket begin=")
-        start = xmp.index("?>", start) + 2
-        end = xmp.index("</x:xmpmeta>") + 12
+        start = xmp.index(b"<?xpacket begin=")
+        start = xmp.index(b"?>", start) + 2
+        end = xmp.index(b"</x:xmpmeta>") + 12
 
         # Extract XML
         xml = xmp[start:end]

--- a/pyavm/extract.py
+++ b/pyavm/extract.py
@@ -30,7 +30,7 @@ def extract_xmp(image):
 
         # Loop through chunks and search for XMP packet
         for chunk in png_file.chunks:
-            if chunk.type == 'iTXt':
+            if chunk.type == b'iTXt':
                 if chunk.data.startswith(b'XML:com.adobe.xmp'):
                     return chunk.data[22:]
 


### PR DESCRIPTION
All in the title.  I haven't tested on py2, but it definitely didn't work on py3.

Is it OK to have astropy as a requirement?  It simplifies the import.
