### PR TITLE
Fix comparison with literal

### DIFF
--- a/pyavm/datatypes.py
+++ b/pyavm/datatypes.py
@@ -344,7 +344,7 @@ class AVMUnorderedList(AVMData):
         for value in values:
             value = value
             length += len(value)
-            if value is "":
+            if value == "":
                 value = "-"
             checked_data.append(value)
 


### PR DESCRIPTION
This is a little glitch that we observed on the transition to Python 3.8.
Reported as [Debian#950222](https://bugs.debian.org/950222) by @doko42.