### PR TITLE
Add `target_shape` argument to `AVM.to_wcs()`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ sudo: false
 
 python:
     - 2.7
-    - 3.5
     - 3.6
+    - 3.7
+    - 3.8
 
 env:
   matrix:

--- a/pyavm/tests/test_main.py
+++ b/pyavm/tests/test_main.py
@@ -58,6 +58,15 @@ def test_to_wcs_target_image(filename, tmpdir):
     a.to_wcs(target_image=image_file)
 
 
+@pytest.mark.parametrize('filename', XML_FILES_WCS)
+def test_to_wcs_target_shape(filename, tmpdir):
+    pytest.importorskip('PIL')
+    pytest.importorskip('astropy')
+    a = AVM.from_xml_file(filename)
+    a.Spatial.ReferenceDimension = (30, 30)
+    a.to_wcs(target_shape=(2, 2))
+
+
 @pytest.mark.parametrize('filename', NO_WCS)
 def test_to_wcs_nowcs(filename):
     pytest.importorskip('astropy')


### PR DESCRIPTION
Sometimes we know what shape we want without needing (or being able to) load an image from disk.