### PR TITLE
Correct XML output: ordered lists are rdf:Seq, not rdf:Bag

### DIFF
--- a/pyavm/datatypes.py
+++ b/pyavm/datatypes.py
@@ -540,7 +540,7 @@ class AVMOrderedFloatList(AVMOrderedList):
         uri = reverse_namespaces[self.namespace]
         element = et.SubElement(parent, "{%s}%s" % (uri, self.tag))
 
-        subelement = et.SubElement(element, "rdf:Bag")
+        subelement = et.SubElement(element, "rdf:Seq")
 
         for item in values:
             li = et.SubElement(subelement, "rdf:li")


### PR DESCRIPTION
The `AVMOrderedFloatList` was using `rdf:Bag` instead of `rdf:Seq`, creating incorrect XML output.

CC @keflavich

PS: I should add a test, I know.