### PR TITLE
Fix bad function call

### DIFF
--- a/pyavm/avm.py
+++ b/pyavm/avm.py
@@ -460,7 +460,7 @@ class AVM(AVMContainer):
             raise NoSpatialInformation("AVM meta-data does not contain any spatial information")
 
         if use_full_header and self.Spatial.FITSheader is not None:
-            header = fits.Header.from_string(self.Spatial.FITSheader)
+            header = fits.Header.fromstring(self.Spatial.FITSheader)
             return WCS(header)
 
         # Initializing WCS object


### PR DESCRIPTION
https://docs.astropy.org/en/stable/io/fits/api/headers.html#astropy.io.fits.Header.fromstring there's no underscore

This likely indicates a need for better test coverage