### PR TITLE
Treat tag values given as a list containing a single empty item as absent

### DIFF
--- a/pyavm/datatypes.py
+++ b/pyavm/datatypes.py
@@ -69,6 +69,10 @@ class AVMString(AVMData):
             return None
         if isinstance(value, (list, tuple)) and len(value) == 1:
             value = value[0]
+        if value is None:
+            # This can happen e.g. for list values containing a single empty
+            # item, and should be treated as the value being absent.
+            return None
         if isinstance(value, str):
             return value if value else None
         elif isinstance(value, (int, float)):

--- a/pyavm/tests/test_avm.py
+++ b/pyavm/tests/test_avm.py
@@ -130,3 +130,18 @@ def test_avm_iteration():
     tag_names = [name for name, value in items]
     assert "Title" in tag_names
     assert "Spatial.Equinox" in tag_names
+
+
+def test_from_xml_empty_list_value():
+    # Some images in the wild (e.g. current images from eso.org) contain tags
+    # with a list containing a single empty item, which should be treated the
+    # same as the tag being absent.
+    with open(os.path.join(ROOT, "3c321.avm.xml")) as f:
+        content = f.read()
+    content = content.replace(
+        "<avm:Type>Observation</avm:Type>",
+        "<avm:Type>Observation</avm:Type>"
+        "<avm:Spatial.Notes><rdf:Alt><rdf:li/></rdf:Alt></avm:Spatial.Notes>",
+    )
+    avm = AVM.from_xml(content.encode("utf-8"))
+    assert avm.Spatial.Notes is None


### PR DESCRIPTION
This is to fix an issue encountered with real images in the wild